### PR TITLE
[WIP]Chat-SpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|text|null: false|
+|name|string|null: false|
 ### Association
 - has_many :usrs, through:  :groups_users
 - has_many :messages

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups, through:  :groups_users

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :groups, through:  :groups_users
+- has_many :groups_users
 
 ## groupsテーブル
 |Column|Type|Options|
@@ -41,6 +42,7 @@ Things you may want to cover:
 ### Association
 - has_many :usrs, through:  :groups_users
 - has_many :messages
+- has_many :groups_users
 
 ## groups_usersテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Things you may want to cover:
 |------|----|-------|
 |name|string|null: false|
 ### Association
-- has_many :usrs, through:  :groups_users
+- has_many :users, through:  :groups_users
 - has_many :messages
 - has_many :groups_users
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,42 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+# ChatSpace DB設計
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups, through:  :groups_users
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|text|null: false|
+### Association
+- has_many :usrs, through:  :groups_users
+- has_many :messages
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|text||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|text||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|


### PR DESCRIPTION
# What
chat-spaceアプリケーションのデータベース設計
usersテーブルにemailカラム、passwordカラム、usernameカラムを追加
groupsテーブルにgroupnameカラムを追加
中間テーブルとしてgroups_usersテーブルを追加
messagesテーブルにtextカラム、imageカラム、user＿idカラム、group_idカラムを追加
# Why
chat-spaceアプリの作成にあたりDBが必要となるため。